### PR TITLE
Add regression assumption checks and violation examples to tutorials

### DIFF
--- a/tutorials/04-lm-basics.qmd
+++ b/tutorials/04-lm-basics.qmd
@@ -231,6 +231,40 @@ predict(fit_species, newdata = new_penguins)
 
 :::
 
+---
+
+## Assumption checks and common violations
+
+Linear models assume a linear mean structure, roughly constant variance, and approximately normal residuals.  
+Use the diagnostic columns from `augment()` to look for these issues.
+
+```{r}
+augmented <- augment(fit_species)
+
+# Linearity and equal variance (no patterns or fan shapes)
+ggplot(augmented, aes(x = .fitted, y = .resid)) +
+  geom_point(alpha = 0.6) +
+  geom_hline(yintercept = 0, linewidth = 0.3) +
+  labs(x = "Fitted bill length", y = "Residuals") +
+  theme_minimal()
+
+# Normality check (points should track the line)
+ggplot(augmented, aes(sample = .std.resid)) +
+  stat_qq() +
+  stat_qq_line() +
+  labs(x = "Theoretical quantiles", y = "Standardised residuals") +
+  theme_minimal()
+```
+
+:::{.callout-warning}
+Examples of assumption violations to watch for:
+
+* **Curvature** in the residual plot (suggests a missing nonlinear term).
+* **Funnel or fan shapes** in residual spread (heteroskedasticity).
+* **Heavy tails or S-shaped QQ plot** (non-normal residuals).
+* **Large Cook's distance values** (influential observations).
+:::
+
 ## Summarise residual variation
 
 Residual summaries quantify how well the model captures the observed data.

--- a/tutorials/05-logistic-basics.qmd
+++ b/tutorials/05-logistic-basics.qmd
@@ -178,6 +178,40 @@ predict(fit_logit, newdata = new_penguin, type = "response")
 
 ---
 
+## Assumption checks and common violations
+
+Logistic regression assumes a linear relationship between predictors and the **log-odds**, independent observations, and no complete separation.  
+You can check calibration by comparing predicted probabilities to observed outcomes in bins.
+
+```{r}
+augmented <- augment(fit_logit, type.predict = "response") |>
+  mutate(outcome = if_else(sex == "male", 1, 0))
+
+augmented |>
+  mutate(bin = cut(bill_dep, breaks = 6)) |>
+  group_by(bin) |>
+  summarise(
+    mean_prob = mean(.fitted),
+    mean_resid = mean(outcome - .fitted),
+    .groups = "drop"
+  ) |>
+  ggplot(aes(x = mean_prob, y = mean_resid)) +
+  geom_point() +
+  geom_hline(yintercept = 0, linewidth = 0.3) +
+  labs(x = "Mean predicted probability", y = "Mean residual (observed - predicted)") +
+  theme_minimal()
+```
+
+:::{.callout-warning}
+Examples of assumption violations to watch for:
+
+* **Systematic trends** in binned residuals (nonlinearity on the log-odds scale).
+* **Complete separation** (model warnings about fitted probabilities of 0 or 1).
+* **Extreme leverage or influence** (a small number of points dominating the fit).
+:::
+
+---
+
 ## Evaluate classification performance
 
 Compare predicted probabilities to the observed classes using a threshold (e.g., 0.5) and calculate accuracy.


### PR DESCRIPTION
### Motivation

- Improve the regression chapters by explicitly teaching how to check model assumptions and recognise common violations for both linear and logistic models. 

### Description

- Add an "Assumption checks and common violations" section to `tutorials/04-lm-basics.qmd` that uses `augment()` diagnostics, a fitted vs residuals plot, and a QQ plot of standardized residuals, and lists common issues such as curvature, heteroskedasticity, non-normal residuals, and influential observations. 
- Add an "Assumption checks and common violations" section to `tutorials/05-logistic-basics.qmd` that uses `augment(..., type.predict = "response")`, a binned-residuals calibration example, and lists issues such as nonlinearity on the log-odds scale, complete separation, and extreme influence. 
- Include in-chapter runnable code snippets and callout warnings to help learners apply the checks to their own models. 

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ec8efc6c8332a8076959454bbeb8)