### PR TITLE
Add independence, calibration, and influence checks to linear and logistic tutorials

### DIFF
--- a/tutorials/04-lm-basics.qmd
+++ b/tutorials/04-lm-basics.qmd
@@ -157,9 +157,71 @@ tidy(fit_species, conf.int = TRUE, conf.level = 0.95)
 
 ---
 
+## Assess model fit and compare models
+
+Use `glance()` to summarise overall model fit for linear models.  
+Key statistics include:
+
+* **`r.squared` and `adj.r.squared`**: proportion of variance explained (adjusted accounts for extra predictors).
+* **`sigma`**: residual standard error (lower values indicate tighter residuals).
+* **`AIC` and `BIC`**: information criteria for comparing models (lower is better).
+
+When comparing **nested** models (one model is a special case of the other), use `anova()` with both models to test whether the larger model improves fit.
+
+::: {.panel-tabset}
+
+### Example
+
+Compare fit summaries for two models and look at information criteria.
+
+```{r}
+bind_rows(
+  glance(fit_simple) |> mutate(model = "bill_dep"),
+  glance(fit_species) |> mutate(model = "bill_dep + species")
+) |>
+  select(model, r.squared, adj.r.squared, sigma, AIC, BIC)
+```
+
+Test whether adding `species` improves the fit relative to the simpler model.
+
+```{r}
+anova(fit_simple, fit_species)
+```
+
+### Exercise
+
+Using the same two models, extract only `AIC` and `BIC` for comparison. Replace the blanks.
+
+```{r}
+#| eval: false
+
+bind_rows(
+  glance(____) |> mutate(model = "bill_dep"),
+  glance(____) |> mutate(model = "bill_dep + species")
+) |>
+  select(model, AIC, BIC)
+```
+
+### Solution
+
+```{r}
+#| code-fold: true
+#| code-summary: "Show solution"
+
+bind_rows(
+  glance(fit_simple) |> mutate(model = "bill_dep"),
+  glance(fit_species) |> mutate(model = "bill_dep + species")
+) |>
+  select(model, AIC, BIC)
+```
+
+:::
+
+---
+
 ## Check diagnostics and predict
 
-Use `augment()` for row-level diagnostics and `glance()` for overall model fit.  
+Use `augment()` for row-level diagnostics.  
 Residuals should scatter randomly around zero; systematic patterns may indicate model misspecification.  
 Predictions require a tibble of new values using the same variable names as in the model.
 
@@ -235,17 +297,39 @@ predict(fit_species, newdata = new_penguins)
 
 ## Assumption checks and common violations
 
-Linear models assume a linear mean structure, roughly constant variance, and approximately normal residuals.  
+Linear models rely on several assumptions; violations can lead to biased estimates or unreliable inference.  
 Use the diagnostic columns from `augment()` to look for these issues.
 
+**Key assumptions and what they mean:**
+
+* **Linearity**: the mean response changes linearly with each predictor (or with the linear predictor after any transformations).
+* **Independence**: observations are independent, so residuals are not correlated across rows.
+* **Constant variance (homoskedasticity)**: residual spread is roughly the same across fitted values.
+* **Normal residuals**: residuals are approximately normal, which matters most for small-sample inference.
+* **No extreme influence**: a small number of observations should not dominate the fitted line.
+
+::: {.panel-tabset}
+
+### Example
+
+Check linearity and equal variance with a residuals-versus-fitted plot, assess independence with residuals by row order, and check normality with a QQ plot.
+
 ```{r}
-augmented <- augment(fit_species)
+augmented <- augment(fit_species) |>
+  mutate(row_id = row_number())
 
 # Linearity and equal variance (no patterns or fan shapes)
 ggplot(augmented, aes(x = .fitted, y = .resid)) +
   geom_point(alpha = 0.6) +
   geom_hline(yintercept = 0, linewidth = 0.3) +
   labs(x = "Fitted bill length", y = "Residuals") +
+  theme_minimal()
+
+# Independence check (no runs or trends across row order)
+ggplot(augmented, aes(x = row_id, y = .resid)) +
+  geom_point(alpha = 0.6) +
+  geom_hline(yintercept = 0, linewidth = 0.3) +
+  labs(x = "Row order", y = "Residuals") +
   theme_minimal()
 
 # Normality check (points should track the line)
@@ -255,6 +339,33 @@ ggplot(augmented, aes(sample = .std.resid)) +
   labs(x = "Theoretical quantiles", y = "Standardised residuals") +
   theme_minimal()
 ```
+
+### Exercise
+
+Use the same `augmented` tibble to flag potentially influential observations by sorting on Cook's distance. Replace the blanks.
+
+```{r}
+#| eval: false
+
+augmented |>
+  arrange(desc(____)) |>
+  select(.cooksd, .fitted, .resid) |>
+  head(5)
+```
+
+### Solution
+
+```{r}
+#| code-fold: true
+#| code-summary: "Show solution"
+
+augmented |>
+  arrange(desc(.cooksd)) |>
+  select(.cooksd, .fitted, .resid) |>
+  head(5)
+```
+
+:::
 
 :::{.callout-warning}
 Examples of assumption violations to watch for:

--- a/tutorials/05-logistic-basics.qmd
+++ b/tutorials/05-logistic-basics.qmd
@@ -126,6 +126,59 @@ tidy(fit_logit, exponentiate = TRUE, conf.int = FALSE)
 
 ---
 
+## Assess model fit and compare models
+
+Use `glance()` to summarise overall fit for logistic regression.  
+Key statistics include:
+
+* **`deviance` and `null.deviance`**: smaller deviance indicates better fit relative to the saturated model.
+* **`AIC` and `BIC`**: information criteria for comparing models (lower is better).
+
+For **nested** models, compare fits with a likelihood ratio test using `anova(..., test = "Chisq")`.
+
+::: {.panel-tabset}
+
+### Example
+
+Compare model summaries for the single-predictor and two-predictor models.
+
+```{r}
+bind_rows(
+  glance(fit_logit) |> mutate(model = "bill_dep"),
+  glance(fit_two_predictors) |> mutate(model = "bill_dep + bill_len")
+) |>
+  select(model, deviance, null.deviance, AIC, BIC)
+```
+
+Test whether adding `bill_len` improves model fit.
+
+```{r}
+anova(fit_logit, fit_two_predictors, test = "Chisq")
+```
+
+### Exercise
+
+Use `AIC()` to compare the two models directly. Replace the blanks.
+
+```{r}
+#| eval: false
+
+AIC(____, ____)
+```
+
+### Solution
+
+```{r}
+#| code-fold: true
+#| code-summary: "Show solution"
+
+AIC(fit_logit, fit_two_predictors)
+```
+
+:::
+
+---
+
 ## Predict probabilities
 
 Use `augment()` with `type.predict = "response"` to compute fitted probabilities instead of log-odds.
@@ -180,12 +233,35 @@ predict(fit_logit, newdata = new_penguin, type = "response")
 
 ## Assumption checks and common violations
 
-Logistic regression assumes a linear relationship between predictors and the **log-odds**, independent observations, and no complete separation.  
+Logistic regression has model assumptions that guide diagnostics and interpretation.  
 You can check calibration by comparing predicted probabilities to observed outcomes in bins.
+
+**Key assumptions and what they mean:**
+
+* **Correct link and linearity in the log-odds**: predictors relate linearly to the log-odds of the outcome.
+* **Independence**: observations are independent (no repeated measures without accounting for them).
+* **No complete separation**: predictors should not perfectly predict the outcome.
+* **Adequate sample size**: enough events per predictor to avoid unstable estimates.
+* **No extreme influence**: single points should not dominate the estimated probabilities.
+
+::: {.panel-tabset}
+
+### Example
+
+Check calibration by comparing binned predicted probabilities to observed outcomes, then review event counts, extreme fitted probabilities, and influential points.
 
 ```{r}
 augmented <- augment(fit_logit, type.predict = "response") |>
-  mutate(outcome = if_else(sex == "male", 1, 0))
+  mutate(
+    outcome = if_else(sex == "male", 1, 0),
+    row_id = row_number()
+  )
+
+augmented |>
+  summarise(
+    events = sum(outcome),
+    nonevents = sum(1 - outcome)
+  )
 
 augmented |>
   mutate(bin = cut(bill_dep, breaks = 6)) |>
@@ -200,7 +276,57 @@ augmented |>
   geom_hline(yintercept = 0, linewidth = 0.3) +
   labs(x = "Mean predicted probability", y = "Mean residual (observed - predicted)") +
   theme_minimal()
+
+augmented |>
+  ggplot(aes(x = row_id, y = outcome - .fitted)) +
+  geom_point(alpha = 0.6) +
+  geom_hline(yintercept = 0, linewidth = 0.3) +
+  labs(x = "Row order", y = "Residual (observed - predicted)") +
+  theme_minimal()
+
+augmented |>
+  summarise(min_prob = min(.fitted), max_prob = max(.fitted))
+
+augmented |>
+  arrange(desc(.cooksd)) |>
+  select(.cooksd, .fitted, bill_dep) |>
+  head(5)
 ```
+
+### Exercise
+
+Create a binned calibration table that reports the mean predicted probability and the observed proportion of males in each bin. Replace the blanks.
+
+```{r}
+#| eval: false
+
+augmented |>
+  mutate(bin = cut(bill_dep, breaks = 6)) |>
+  group_by(bin) |>
+  summarise(
+    mean_prob = mean(.fitted),
+    prop_male = mean(____),
+    .groups = "drop"
+  )
+```
+
+### Solution
+
+```{r}
+#| code-fold: true
+#| code-summary: "Show solution"
+
+augmented |>
+  mutate(bin = cut(bill_dep, breaks = 6)) |>
+  group_by(bin) |>
+  summarise(
+    mean_prob = mean(.fitted),
+    prop_male = mean(outcome),
+    .groups = "drop"
+  )
+```
+
+:::
 
 :::{.callout-warning}
 Examples of assumption violations to watch for:


### PR DESCRIPTION
### Motivation

- Ensure tutorials demonstrate all common assumption checks so learners can identify model misspecification and influence.  
- Give clear, actionable guidance for assessing overall model fit and comparing nested models.  
- Make calibration and influence diagnostics explicit for logistic models to catch separation, extreme probabilities, and leverage.

### Description

- In `tutorials/04-lm-basics.qmd` add an "Assess model fit and compare models" section showing `glance()`, `AIC`/`BIC`, and `anova()` for nested-model tests and add an independence diagnostic by adding `row_id` and plotting residuals by row order.  
- In `tutorials/04-lm-basics.qmd` add a Cook's distance exercise and solution that demonstrates sorting the `augment()` output by `.cooksd`.  
- In `tutorials/05-logistic-basics.qmd` add an "Assess model fit and compare models" section showing `glance()`, `deviance`, `AIC`/`BIC`, and `anova(..., test = "Chisq")`, and add `row_id` to `augment()` output to support an independence residual plot.  
- In `tutorials/05-logistic-basics.qmd` add checks for event counts, extreme fitted probabilities (`min`/`max` of `.fitted`), and a top-5 influence scan via `.cooksd`, plus update the binned calibration exercise and folded solution to use `outcome`.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f3d943748332a24f8bb8db5ec2fe)